### PR TITLE
fix(parser): restore doppler on tone tracks

### DIFF
--- a/internal/parser/track.go
+++ b/internal/parser/track.go
@@ -119,7 +119,7 @@ func (ctx *TextParser) ParseTrackDeclaration() (*ParsedTrackDeclaration, error) 
 		}
 
 		if kind == t.KeywordEffect {
-			effectKind, err := ctx.Line.NextExpectOneOf(t.KeywordPan, t.KeywordModulation, t.KeywordShift)
+			effectKind, err := ctx.Line.NextExpectOneOf(t.KeywordPan, t.KeywordModulation, t.KeywordDoppler, t.KeywordShift)
 			if err != nil {
 				return nil, err
 			}
@@ -135,6 +135,8 @@ func (ctx *TextParser) ParseTrackDeclaration() (*ParsedTrackDeclaration, error) 
 				decl.EffectType = t.EffectPan
 			case t.KeywordModulation:
 				decl.EffectType = t.EffectModulation
+			case t.KeywordDoppler:
+				decl.EffectType = t.EffectDoppler
 			case t.KeywordShift:
 				decl.EffectType = t.EffectShift
 			}

--- a/internal/parser/track_test.go
+++ b/internal/parser/track_test.go
@@ -94,6 +94,7 @@ func TestParseTrack_Tones(ts *testing.T) {
 		{fmtLine(toTrack(trs[2])), *trs[2]},
 		{toTrack(trs[3]).String(), *trs[3]},
 		{toTrack(trs[4]).String(), *trs[4]},
+		{"tone 180 binaural 8.5 effect doppler 8.5 intensity 10 amplitude 7.5", ParsedTrackDeclaration{Type: t.TrackBinauralBeat, Carrier: 180, Resonance: 8.5, EffectType: t.EffectDoppler, EffectValue: 8.5, EffectIntensityPercent: 10, AmplitudePercent: 7.5, Waveform: t.WaveformSine}},
 		{"tone 300 effect shift 10 intensity 25 amplitude 20", ParsedTrackDeclaration{Type: t.TrackPureTone, Carrier: 300, EffectType: t.EffectShift, EffectValue: 10, EffectIntensityPercent: 25, AmplitudePercent: 20, Waveform: t.WaveformSine}},
 		{"tone 300 binaural 8 effect shift 4 intensity 20 amplitude 20", ParsedTrackDeclaration{Type: t.TrackBinauralBeat, Carrier: 300, Resonance: 8, EffectType: t.EffectShift, EffectValue: 4, EffectIntensityPercent: 20, AmplitudePercent: 20, Waveform: t.WaveformSine}},
 		{"tone 300 monaural 8 effect shift 4 intensity 20 amplitude 20", ParsedTrackDeclaration{Type: t.TrackMonauralBeat, Carrier: 300, Resonance: 8, EffectType: t.EffectShift, EffectValue: 4, EffectIntensityPercent: 20, AmplitudePercent: 20, Waveform: t.WaveformSine}},


### PR DESCRIPTION
## Summary
- restore `doppler` as an accepted tone effect
- add a regression test for binaural tone Doppler syntax

## Validation
- `go test ./internal/parser ./internal/sequence ./spsq`
- `make build`
- `bin/synapseq -test /Users/ruan/Music/SynapSeq/Void/void.spsq`