### PR TITLE
fix(audio): report lazy remote source failures

### DIFF
--- a/internal/audio/audiosource/audio.go
+++ b/internal/audio/audiosource/audio.go
@@ -484,10 +484,7 @@ func (aa *Audio) ReadSamplesAt(index int, samples []int, numSamples int) (int, e
 				return numSamples, nil
 			}
 			if restartErr := aa.restartAt(index); restartErr != nil {
-				for i := samplesRead; i < numSamples; i++ {
-					samples[i] = 0
-				}
-				return numSamples, nil
+				return samplesRead, fmt.Errorf("failed to restart %s audio index %d: %w", aa.sourceKind, index, restartErr)
 			}
 			continue
 		}

--- a/internal/audio/audiosource/runtime.go
+++ b/internal/audio/audiosource/runtime.go
@@ -71,6 +71,7 @@ type Runtime struct {
 	dopplerPos   [t.NumberOfChannels]float64
 	dopplerMask  [t.NumberOfChannels]bool
 	periodStart  [][]int
+	err          error
 }
 
 func NewRuntime(periods []t.Period, sources map[string]string, sampleRate int, opts RuntimeOptions) (*Runtime, error) {
@@ -247,6 +248,15 @@ func (ar *Runtime) Close() error {
 	return firstErr
 }
 
+// Err returns the first external audio failure encountered during rendering.
+func (ar *Runtime) Err() error {
+	if ar == nil {
+		return nil
+	}
+
+	return ar.err
+}
+
 func (ar *Runtime) UpdateChannelIndex(ch int, periodIdx int, trackType t.TrackType) {
 	if ar == nil || ch < 0 || ch >= len(ar.channelIdx) {
 		return
@@ -267,6 +277,8 @@ func (ar *Runtime) UpdateChannelIndex(ch int, periodIdx int, trackType t.TrackTy
 				if err := audio.SelectAudio(nextIdx); err == nil {
 					ar.channelIdx[ch] = nextIdx
 					return
+				} else {
+					ar.recordError(err)
 				}
 			}
 		}
@@ -362,6 +374,7 @@ func (ar *Runtime) PrepareBuffers(bufferSize int) {
 		}
 
 		if _, err := ar.audio.ReadSamplesAt(idx, buf, need); err != nil {
+			ar.recordError(err)
 			zeroSamples(buf)
 		}
 	}
@@ -395,11 +408,13 @@ func (ar *Runtime) prepareChannelBuffers(bufferSize int) {
 
 		audio, err := ar.audioForChannel(ch)
 		if err != nil || audio == nil {
+			ar.recordError(err)
 			zeroSamples(buf)
 			continue
 		}
 
 		if _, err := audio.ReadSamplesAt(idx, buf, need); err != nil {
+			ar.recordError(err)
 			zeroSamples(buf)
 		}
 	}
@@ -448,7 +463,7 @@ func (ar *Runtime) ResetDoppler(ch int) {
 		return
 	}
 	if audio, ok := ar.dopplerPlaybackAudio(ch).(bufferedCursorSampleAudio); ok {
-		_ = audio.RewindBufferedFrames(ar.channelIdx[ch], ar.dopplerCount[ch])
+		ar.recordError(audio.RewindBufferedFrames(ar.channelIdx[ch], ar.dopplerCount[ch]))
 	}
 	ar.closeDopplerAudio(ch)
 	ar.dopplerBuf[ch] = nil
@@ -466,6 +481,7 @@ func (ar *Runtime) ensureDopplerFrames(ch, needed int) bool {
 	}
 	audio, err := ar.dopplerAudioForChannel(ch)
 	if err != nil || audio == nil {
+		ar.recordError(err)
 		return false
 	}
 
@@ -511,7 +527,11 @@ func (ar *Runtime) readDopplerFrameRange(ch int, audio SampleAudio, startFrame, 
 	start := startFrame * stereoChannels
 	end := start + frames*stereoChannels
 	_, err := audio.ReadSamplesAt(ar.channelIdx[ch], ar.dopplerBuf[ch][start:end], end-start)
-	return err == nil
+	if err != nil {
+		ar.recordError(err)
+		return false
+	}
+	return true
 }
 
 func (ar *Runtime) dopplerFrameCapacity(ch int) int {
@@ -614,6 +634,12 @@ func (ar *Runtime) closeChannelAudio(ch int) {
 	_ = ar.channelAudio[ch].Close()
 	ar.channelAudio[ch] = nil
 	ar.samplesByCh[ch] = nil
+}
+
+func (ar *Runtime) recordError(err error) {
+	if ar.err == nil && err != nil {
+		ar.err = err
+	}
 }
 
 func (ar *Runtime) ChannelBuffer(ch int) []int {

--- a/internal/audio/rendercycle.go
+++ b/internal/audio/rendercycle.go
@@ -46,10 +46,15 @@ func (rr *renderRuntime) run() error {
 	for rr.framesWritten < rr.totalFrames {
 		currentTimeMs := rr.currentTimeMs()
 		rr.advancePeriod(currentTimeMs)
-		rr.syncAndPrepare(currentTimeMs)
+		if err := rr.syncAndPrepare(currentTimeMs); err != nil {
+			return err
+		}
 		rr.reportPeriodChange()
 
 		data, framesToWrite := rr.mixCurrentChunk()
+		if err := rr.externalAudioError(); err != nil {
+			return err
+		}
 		if err := rr.consumeChunk(data); err != nil {
 			return err
 		}
@@ -69,7 +74,7 @@ func (rr *renderRuntime) advancePeriod(currentTimeMs int) {
 	rr.periodIdx = rr.renderer.plan.periodIndexAt(currentTimeMs, rr.periodIdx)
 }
 
-func (rr *renderRuntime) syncAndPrepare(currentTimeMs int) {
+func (rr *renderRuntime) syncAndPrepare(currentTimeMs int) error {
 	cue := rr.renderer.plan.cue(rr.periodIdx, currentTimeMs)
 	rr.renderer.applyCueSignalState(cue)
 	rr.renderer.syncEngine.Sync(rr.renderer.channels[:], cue)
@@ -81,6 +86,18 @@ func (rr *renderRuntime) syncAndPrepare(currentTimeMs int) {
 		rr.renderer.musicState.CollectActiveIndices(rr.renderer.channels[:])
 		rr.renderer.musicState.PrepareBuffers(t.BufferSize)
 	}
+
+	return rr.externalAudioError()
+}
+
+func (rr *renderRuntime) externalAudioError() error {
+	if err := rr.renderer.ambianceState.Err(); err != nil {
+		return fmt.Errorf("ambiance audio: %w", err)
+	}
+	if err := rr.renderer.musicState.Err(); err != nil {
+		return fmt.Errorf("music audio: %w", err)
+	}
+	return nil
 }
 
 func (rr *renderRuntime) reportPeriodChange() {

--- a/internal/audio/renderer_test.go
+++ b/internal/audio/renderer_test.go
@@ -7,6 +7,8 @@ package audio
 import (
 	"errors"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -545,5 +547,68 @@ func TestNewAudioRendererRejectsUnknownWaveform(ts *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), `unknown waveform "missing"`) {
 		ts.Fatalf("expected unknown waveform error, got %v", err)
+	}
+}
+
+func TestAudioRendererReportsLazyRemoteAudioFailure(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name      string
+		trackType t.TrackType
+		sources   map[string]string
+	}{
+		{
+			name:      "ambiance",
+			trackType: t.TrackAmbiance,
+			sources:   map[string]string{"missing": server.URL + "/missing.wav"},
+		},
+		{
+			name:      "music",
+			trackType: t.TrackMusic,
+			sources:   map[string]string{"missing": server.URL + "/missing.mp3"},
+		},
+	}
+
+	for _, test := range tests {
+		ts.Run(test.name, func(ts *testing.T) {
+			var start, end t.Period
+			start.TrackStart[0] = t.Track{
+				Type:       test.trackType,
+				SourceName: "missing",
+				Amplitude:  t.AmplitudePercentToRaw(10),
+				Waveform:   t.WaveformSine,
+			}
+			start.TrackEnd[0] = start.TrackStart[0]
+			end.Time = 100
+
+			options := &AudioRendererOptions{
+				SampleRate: 44100,
+				Volume:     100,
+				Ambiance:   map[string]string{},
+				Music:      map[string]string{},
+			}
+			if test.trackType == t.TrackAmbiance {
+				options.Ambiance = test.sources
+			} else {
+				options.Music = test.sources
+			}
+
+			renderer, err := NewAudioRenderer([]t.Period{start, end}, options)
+			if err != nil {
+				ts.Fatalf("NewAudioRenderer: %v", err)
+			}
+
+			err = renderer.Render(nil)
+			if err == nil {
+				ts.Fatal("expected lazy remote audio failure")
+			}
+			if !strings.Contains(err.Error(), "404 Not Found") {
+				ts.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/internal/resource/file.go
+++ b/internal/resource/file.go
@@ -183,13 +183,16 @@ func copyFile(src, dst string, mode os.FileMode) error {
 func getRemoteFile(url string, maxSize int64) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching remote file: %v", err)
+		return nil, fmt.Errorf("error fetching remote file: %w", err)
 	}
 	defer resp.Body.Close()
+	if err := validateRemoteResponse(resp); err != nil {
+		return nil, err
+	}
 
 	data, err := readFile(resp.Body, maxSize)
 	if err != nil {
-		return nil, fmt.Errorf("error reading remote file: %v", err)
+		return nil, fmt.Errorf("error reading remote file: %w", err)
 	}
 
 	return data, nil
@@ -208,9 +211,12 @@ func getRemoteAudioFile(rawURL string, maxSize int64, sourceKind string) ([]byte
 
 	resp, err := http.Get(rawURL)
 	if err != nil {
-		return nil, t.AmbianceAudioUnknown, fmt.Errorf("error fetching remote file: %v", err)
+		return nil, t.AmbianceAudioUnknown, fmt.Errorf("error fetching remote file: %w", err)
 	}
 	defer resp.Body.Close()
+	if err := validateRemoteResponse(resp); err != nil {
+		return nil, t.AmbianceAudioUnknown, err
+	}
 
 	if format == t.AmbianceAudioUnknown {
 		format, err = audioFormatFromMIME(resp.Header.Get("Content-Type"), sourceKind)
@@ -221,8 +227,16 @@ func getRemoteAudioFile(rawURL string, maxSize int64, sourceKind string) ([]byte
 
 	data, err := readFile(resp.Body, maxSize)
 	if err != nil {
-		return nil, t.AmbianceAudioUnknown, fmt.Errorf("error reading remote file: %v", err)
+		return nil, t.AmbianceAudioUnknown, fmt.Errorf("error reading remote file: %w", err)
 	}
 
 	return data, format, nil
+}
+
+func validateRemoteResponse(resp *http.Response) error {
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return nil
+	}
+
+	return fmt.Errorf("remote server returned %s", resp.Status)
 }

--- a/internal/resource/file_test.go
+++ b/internal/resource/file_test.go
@@ -197,6 +197,21 @@ func TestGetFile_HTTP_WAV(ts *testing.T) {
 	}
 }
 
+func TestGetFile_HTTPStatusError(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := GetFile(server.URL+"/missing.spsq", t.FormatText)
+	if err == nil {
+		ts.Fatal("expected HTTP status error")
+	}
+	if !strings.Contains(err.Error(), "404 Not Found") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestGetAmbianceFile_HTTPFormatFromExtension(ts *testing.T) {
 	content := []byte("mp3 data")
 
@@ -216,6 +231,41 @@ func TestGetAmbianceFile_HTTPFormatFromExtension(ts *testing.T) {
 	}
 	if !bytes.Equal(got, content) {
 		ts.Errorf("content mismatch")
+	}
+}
+
+func TestGetAmbianceFile_HTTPStatusError(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, _, err := GetAmbianceFile(server.URL + "/missing.wav")
+	if err == nil {
+		ts.Fatal("expected HTTP status error")
+	}
+	if !strings.Contains(err.Error(), "500 Internal Server Error") {
+		ts.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetAmbianceFile_HTTPRedirectToStatusError(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/redirect.wav" {
+			http.Redirect(writer, request, "/missing.wav", http.StatusFound)
+			return
+		}
+
+		writer.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, _, err := GetAmbianceFile(server.URL + "/redirect.wav")
+	if err == nil {
+		ts.Fatal("expected HTTP status error")
+	}
+	if !strings.Contains(err.Error(), "404 Not Found") {
+		ts.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -292,6 +342,21 @@ func TestGetMusicFile_HTTPFormatFromExtension(ts *testing.T) {
 	}
 	if !bytes.Equal(got, content) {
 		ts.Errorf("content mismatch")
+	}
+}
+
+func TestGetMusicFile_HTTPStatusError(ts *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, _, err := GetMusicFile(server.URL + "/missing.mp3")
+	if err == nil {
+		ts.Fatal("expected HTTP status error")
+	}
+	if !strings.Contains(err.Error(), "404 Not Found") {
+		ts.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- reject non-2xx remote resource responses\n- preserve lazy loading while surfacing audio read failures to rendering\n- cover HTTP failures and lazy ambiance/music rendering\n\n## Tests\n- make test